### PR TITLE
Add the dependencies to GCS, S3 and Azure Storage with extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,11 @@ setup(name='polyaxon-client',
           "requests-toolbelt==0.8.0",
           "websocket-client>=0.53.0,<=0.54.0",
       ],
+      extras_require={
+          'gcs': ['google-cloud-storage'],
+          's3': ['boto3', 'botocore'],
+          'azure': ['azure-storage'],
+      },
       classifiers=[
           'Programming Language :: Python',
           'Operating System :: OS Independent',


### PR DESCRIPTION
@mouradmourafiq 

## Overview
I put the extra dependencies to GCS, S3 and Azure Storage, since `extras_require` enables us to controll the installation to keep it lightweight.

## Comments
I haven't made sure if the modified client works or not with google cloud storage, s3 and azure storage yet. When I have time, I would like to do that with GCS. But since I am not a sophisticated AWS and Azure user, I won't be able to test it.

Besides, can you guide me if it has to depends on specific versions of the modules respectively?
For instance,
```
...
   'gcs': ['google-cloud-storage>=1.13.0'],
...
```

## Issue
#11