### PR TITLE
Import tf.keras from public API

### DIFF
--- a/polyaxon_client/tracking/contrib/keras.py
+++ b/polyaxon_client/tracking/contrib/keras.py
@@ -9,7 +9,7 @@ try:
     from keras.callbacks import Callback
 except ImportError:
     try:
-        from tensorflow.python.keras.callbacks import Callback
+        from tensorflow.keras.callbacks import Callback
     except ImportError:
         raise PolyaxonClientException('Keras is required to use PolyaxonKeras')
 


### PR DESCRIPTION
`tensorflow.python` is considered privat and should be avoided if possible. This changes the TensorFlow import to the public `tensorflow.keras` interface.